### PR TITLE
Add DXF parsing with three and dxf-parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,12 @@
       "name": "react-dxf-viewer",
       "version": "1.0.0",
       "license": "MIT",
+      "dependencies": {
+        "dxf-parser": "^1.1.2",
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0",
+        "three": "^0.178.0"
+      },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.7",
         "@rollup/plugin-node-resolve": "^15.2.3",
@@ -172,6 +178,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dxf-parser": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/dxf-parser/-/dxf-parser-1.1.2.tgz",
+      "integrity": "sha512-GPTumUvRkounlIazLIyJMmTWt+nlg+ksS0Hdm8jWvejmZKBTz6gvHTam76wRm4PQMma5sgKLThblQyeIJcH79Q==",
+      "license": "MIT",
+      "dependencies": {
+        "loglevel": "^1.7.1"
       }
     },
     "node_modules/estree-walker": {
@@ -379,6 +394,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -520,6 +548,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/react": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
+      "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.26.0"
+      },
+      "peerDependencies": {
+        "react": "^19.1.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -603,6 +652,12 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/scheduler": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -628,6 +683,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/three": {
+      "version": "0.178.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.178.0.tgz",
+      "integrity": "sha512-ybFIB0+x8mz0wnZgSGy2MO/WCO6xZhQSZnmfytSPyNpM0sBafGRVhdaj+erYh5U+RhQOAg/eXqw5uVDiM2BjhQ==",
+      "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,12 @@
     "@rollup/plugin-commonjs": "^25.0.7",
     "rollup-plugin-typescript2": "^0.35.0"
   },
+  "dependencies": {
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "three": "^0.178.0",
+    "dxf-parser": "^1.1.2"
+  },
   "scripts": {
     "build": "rollup -c"
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,5 +24,5 @@ export default {
       useTsconfigDeclarationDir: true
     })
   ],
-  external: ['react', 'react-dom']
+  external: ['react', 'react-dom', 'three', 'dxf-parser']
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,81 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
+import * as THREE from 'three';
+import DxfParser from 'dxf-parser';
 
-export const DxfViewer: React.FC = () => {
-  return null;
+export interface DxfViewerProps {
+  /** URL of the DXF file to load */
+  url?: string;
+  /** Raw DXF string. Used when `url` is not provided */
+  data?: string;
+}
+
+/**
+ * Basic DXF viewer using three.js. It loads a DXF file using `dxf-parser`
+ * and renders simple LINE entities.
+ */
+export const DxfViewer: React.FC<DxfViewerProps> = ({ url, data }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.OrthographicCamera(
+      container.clientWidth / -2,
+      container.clientWidth / 2,
+      container.clientHeight / 2,
+      container.clientHeight / -2,
+      1,
+      1000
+    );
+    camera.position.z = 5;
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setSize(container.clientWidth, container.clientHeight);
+    container.appendChild(renderer.domElement);
+
+    const load = (text: string) => {
+      try {
+        const parser = new DxfParser();
+        const parsed = parser.parseSync(text);
+        if (parsed.entities) {
+          const material = new THREE.LineBasicMaterial({ color: 0x0000ff });
+          parsed.entities.forEach((ent: any) => {
+            if (ent.type === 'LINE') {
+              const geometry = new THREE.BufferGeometry().setFromPoints([
+                new THREE.Vector3(ent.start.x, ent.start.y, 0),
+                new THREE.Vector3(ent.end.x, ent.end.y, 0)
+              ]);
+              const line = new THREE.Line(geometry, material);
+              scene.add(line);
+            }
+          });
+        }
+        renderer.render(scene, camera);
+      } catch (err) {
+        console.error('Error parsing DXF:', err);
+      }
+    };
+
+    if (url) {
+      fetch(url)
+        .then(res => res.text())
+        .then(load)
+        .catch(err => console.error('Failed to load DXF:', err));
+    } else if (data) {
+      load(data);
+    }
+
+    return () => {
+      renderer.dispose();
+      while (container.firstChild) {
+        container.removeChild(container.firstChild);
+      }
+    };
+  }, [url, data]);
+
+  return <div ref={containerRef} style={{ width: '100%', height: '100%' }} />;
 };
 
 export default DxfViewer;


### PR DESCRIPTION
## Summary
- install `react`, `react-dom`, `three`, and `dxf-parser`
- expose basic `DxfViewer` component with DXF parsing logic
- bundle `three` and `dxf-parser` as externals in rollup

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6868d3c7d958832da430882ca4e3f766