### PR TITLE
Add orbit controls render loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 A simple React component for viewing DXF files.
 It supports basic LINE entities and now also renders simple
-`3DFACE` and `SOLID` meshes for quick previews.
+`3DFACE` and `SOLID` meshes for quick previews. The viewer
+includes orbit controls for zooming, panning and rotating the
+scene.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- add orbit controls for interactive zoom/pan/rotate
- add animation loop with requestAnimationFrame
- mention controls in the README

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6868db77a348832d92868f73eabc56c2