### PR TITLE
Add viewer customization options

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,29 @@ It supports basic LINE entities and now also renders simple
 includes orbit controls for zooming, panning and rotating the
 scene.
 
+## Usage
+
+```tsx
+import { DXFViewer } from 'react-dxf-viewer';
+
+export const MyViewer = () => (
+  <div style={{ width: 600, height: 400 }}>
+    <DXFViewer
+      file="example.dxf"
+      cameraPosition={{ x: 0, y: 0, z: 10 }}
+      backgroundColor={0xeeeeee}
+      orbitControls={{ enablePan: false }}
+    />
+  </div>
+);
+```
+
+### Props
+
+- `cameraPosition` – starting position of the camera.
+- `backgroundColor` – background of the three.js scene.
+- `orbitControls` – object of options applied to the `OrbitControls` instance.
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
## Summary
- allow setting initial camera position, scene background color, and `OrbitControls` options
- document new props with an example

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6868dd7244b8832db62f1e5d14ce0705