### PR TITLE
Update README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ scene.
 
 ## Usage
 
+Install the package and import `DXFViewer` in your React component.
+
+```bash
+npm install react-dxf-viewer
+```
+
 ```tsx
 import { DXFViewer } from 'react-dxf-viewer';
 
@@ -23,17 +29,36 @@ export const MyViewer = () => (
 );
 ```
 
+### Loading a local file
+
+You can also pass a `File` object returned from an `<input type="file" />`.
+
+```tsx
+const LocalFileExample = () => {
+  const [file, setFile] = React.useState<File | null>(null);
+
+  return (
+    <div style={{ width: 600, height: 400 }}>
+      <input
+        type="file"
+        accept=".dxf"
+        onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+      />
+      {file && <DXFViewer file={file} />}
+    </div>
+  );
+};
+```
+
 ### Props
 
-- `cameraPosition` – starting position of the camera.
-- `backgroundColor` – background of the three.js scene.
-- `orbitControls` – object of options applied to the `OrbitControls` instance.
-
-## Installation
-
-```bash
-npm install react-dxf-viewer
-```
+- `file` – DXF file to load. Can be a URL string or a `File` object.
+- `className` – optional CSS class applied to the container element.
+- `onLoad` – called when the file has been successfully loaded.
+- `onError` – called with an error if loading or parsing fails.
+- `cameraPosition` – starting position of the camera. Defaults to `{ x: 0, y: 0, z: 5 }`.
+- `backgroundColor` – background color of the three.js scene. Defaults to `0xffffff`.
+- `orbitControls` – object of options passed directly to the `OrbitControls` instance.
 
 ## License
 


### PR DESCRIPTION
## Summary
- show how to install `react-dxf-viewer`
- add example for loading a local DXF file
- document all component props

## Testing
- `npx jest` *(fails: Need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_6868e174c7dc832d94378b952727c345