### PR TITLE
Fix npm package build output

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,16 @@
+node_modules/
+demo/
+*.log
+*.ts
+*.tsx
+*.test.*
+jest.config.js
+jest.setup.ts
+rollup.config.js
+vite.config.ts
+.eslintrc.js
+.eslintignore
+.prettierrc
+.prettierignore
+src/
+!dist/

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,5 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
 };

--- a/package.json
+++ b/package.json
@@ -48,5 +48,8 @@
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,md}\"",
     "lint": "eslint \"src/**/*.{ts,tsx,js,jsx}\"",
     "test": "jest"
-  }
+  },
+  "files": [
+    "dist"
+  ]
 }


### PR DESCRIPTION
## Summary
- include dist folder in the published package
- ignore compiled files when running tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868e810efa4832da64509818c7b23f9