### PR TITLE
Fix DXF viewer clipping

### DIFF
--- a/src/DXFViewer.tsx
+++ b/src/DXFViewer.tsx
@@ -100,7 +100,7 @@ export const DXFViewer: React.FC<DXFViewerProps> = ({
       container.clientWidth / 2,
       container.clientHeight / 2,
       container.clientHeight / -2,
-      1,
+      0.1,
       1000,
     );
     camera.position.set(
@@ -200,7 +200,10 @@ export const DXFViewer: React.FC<DXFViewerProps> = ({
                 ent.end.y,
                 ent.end.z ?? 0,
               );
-              const geometry = new THREE.BufferGeometry().setFromPoints([start, end]);
+              const geometry = new THREE.BufferGeometry().setFromPoints([
+                start,
+                end,
+              ]);
 
               const line = new THREE.Line(geometry, lineMaterial);
               scene.add(line);
@@ -262,11 +265,10 @@ export const DXFViewer: React.FC<DXFViewerProps> = ({
             const size = new THREE.Vector3();
             box.getSize(size);
             const maxDim = Math.max(size.x, size.y);
-            camera.position.set(
-              center.x,
-              center.y,
-              cameraPosition?.z ?? maxDim * 2,
-            );
+            const camZ = cameraPosition?.z ?? maxDim * 2;
+            camera.position.set(center.x, center.y, camZ);
+            camera.near = 0.1;
+            camera.far = camZ * 2;
             camera.updateProjectionMatrix();
           }
         }


### PR DESCRIPTION
## Summary
- adjust near/far clipping range in `DXFViewer`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6868f0a26d10832d8db237765e761b4e